### PR TITLE
Add timeout to frp availability check

### DIFF
--- a/utils/routers/frp.py
+++ b/utils/routers/frp.py
@@ -124,7 +124,7 @@ class FrpRouter(BaseRouter):
 
     def check_availability(self):
         try:
-            resp = self.ses.get(f'{self.url}/api/status')
+            resp = self.ses.get(f'{self.url}/api/status', timeout=2.0)
         except RequestException as e:
             return False, 'Unable to access frpc admin api'
         if resp.status_code == 401:


### PR DESCRIPTION
Without this check, the request could potentially hang indefinitely in the event of an incorrect setup, blocking each request and effectively making the ctfd-whale admin page unavailable. Adding timeout is a simple fix for this simple problem — 2.0 seconds is long enough to not produce false-positives on stable infrastructure, but small enough to not cause much head-ache in case of missconfig.