### PR TITLE
fix: prevent TOCTOU race condition on max container count check

### DIFF
--- a/utils/cache.py
+++ b/utils/cache.py
@@ -104,12 +104,21 @@ class FilesystemCacheProvider:
     def release_lock(self):
         return True
 
+    def acquire_global_lock(self):
+        return True
+
+    def release_global_lock(self):
+        return True
+
 
 class RedisCacheProvider(FlaskRedis):
+    _GLOBAL_CONTAINER_LOCK = 'ctfd_whale_global_container_lock'
+
     def __init__(self, app, *args, **kwargs):
         super().__init__(app)
         self.key = 'ctfd_whale_lock-' + str(kwargs.get('user_id', 0))
         self.current_lock = None
+        self._global_lock = None
         self.global_port_key = "ctfd_whale-port-set"
         self.global_network_key = "ctfd_whale-network-set"
 
@@ -145,6 +154,22 @@ class RedisCacheProvider(FlaskRedis):
         try:
             self.current_lock.release()
 
+            return True
+        except LockError:
+            return False
+
+    def acquire_global_lock(self):
+        lock = self.lock(name=self._GLOBAL_CONTAINER_LOCK, timeout=10)
+        if not lock.acquire(blocking=True, blocking_timeout=5.0):
+            return False
+        self._global_lock = lock
+        return True
+
+    def release_global_lock(self):
+        if self._global_lock is None:
+            return False
+        try:
+            self._global_lock.release()
             return True
         except LockError:
             return False

--- a/utils/control.py
+++ b/utils/control.py
@@ -1,7 +1,9 @@
 import datetime
 import traceback
 
+from flask import current_app
 from CTFd.utils import get_config
+from .cache import CacheProvider
 from .db import DBContainer, db
 from .docker import DockerUtils
 from .routers import Router
@@ -10,13 +12,15 @@ from .routers import Router
 class ControlUtil:
     @staticmethod
     def try_add_container(user_id, challenge_id):
-        if DBContainer.get_all_alive_container_count() > get_config("whale:max_containers", 1000):
-            # TODO: total container count may exceed configured limit if many users create container at the same time
-            # this may happen especially when event is just started
-            # simple solution is to lock this two lines, but implementing a queue system is better
-            # historically this was intensional so players gets a better experience when event is just started, but better fix it still
-            return False, 'Max container count exceed.'
-        container = DBContainer.create_container_record(user_id, challenge_id)
+        cache = CacheProvider(app=current_app)
+        if not cache.acquire_global_lock():
+            return False, 'Server busy, please retry.'
+        try:
+            if DBContainer.get_all_alive_container_count() > get_config("whale:max_containers", 1000):
+                return False, 'Max container count exceed.'
+            container = DBContainer.create_container_record(user_id, challenge_id)
+        finally:
+            cache.release_global_lock()
         try:
             DockerUtils.add_container(container)
             ok, msg = Router.register(container)


### PR DESCRIPTION
## Summary

`ControlUtil.try_add_container` performs a non-atomic check-then-act sequence when enforcing `whale:max_containers`. Between the count read and the `create_container_record` call, no lock is held — concurrent requests from different users each read the same count, all pass the limit check, and all proceed to create containers, exceeding the configured maximum.

The existing `@frequency_limited` decorator uses a **per-user** Redis lock (`ctfd_whale_lock-{user_id}`), which provides no protection against concurrent requests from different users. Two users racing the endpoint hold completely independent locks and never contend with each other.

This was noted in the codebase:
```python
# TODO: total container count may exceed configured limit if many users create container at the same time
# simple solution is to lock this two lines, but implementing a queue system is better
```

This PR implements that simple solution.

## Changes

**`utils/cache.py`** — adds `acquire_global_lock` / `release_global_lock` to both cache providers:
- `RedisCacheProvider`: uses a dedicated key `ctfd_whale_global_container_lock` with a 5s blocking timeout
- `FilesystemCacheProvider`: no-op stubs, consistent with the existing `acquire_lock` behavior (testing only)

**`utils/control.py`** — wraps the count check + `create_container_record` in the global lock:
```python
cache = CacheProvider(app=current_app)
if not cache.acquire_global_lock():
    return False, 'Server busy, please retry.'
try:
    if DBContainer.get_all_alive_container_count() > get_config("whale:max_containers", 1000):
        return False, 'Max container count exceed.'
    container = DBContainer.create_container_record(user_id, challenge_id)
finally:
    cache.release_global_lock()
```

The lock is released immediately after the DB record is created — the Docker and router operations that follow don't need to be serialized.

## Impact

Tested against a live CTFd-Whale deployment with `whale:max_containers = 2`. Three concurrent users each spawned a container simultaneously on the first attempt, exceeding the limit by 50% with no retries needed. In a production CTF with many participants, coordinated exploitation can exhaust host CPU/memory and deny other participants their instances.
